### PR TITLE
Remove horizontal padding from caption

### DIFF
--- a/css/wp-syntax.css
+++ b/css/wp-syntax.css
@@ -24,7 +24,7 @@
 
 .wp_syntax caption {
 	margin          : 0 !important;
-	padding         : 2px !important;
+	padding         : 2px 0 !important;
 	width           : 100% !important;
 	background-color: #def !important;
 	text-align      : left !important;


### PR DESCRIPTION
The caption has 2px padding on every side which causes it to be 4px longer on the right than the other elements
![caption-too-long](https://f.cloud.github.com/assets/840466/565492/b54da3fa-c618-11e2-8616-a857e4dfb217.jpg)

which causes an unnecessary scrollbar on the box containing the code.
![not-nice](https://f.cloud.github.com/assets/840466/565493/bc75a204-c618-11e2-98cc-7e078c2b3830.jpg)

This can be solved by setting the horizontal padding to 0 so that it only has padding above and below. You can still tell that the element is separate from the code (presumably the original intention of the padding) but now it doesn't cause the scrollbar to appear.
![nice-n-sexy](https://f.cloud.github.com/assets/840466/565494/c2a96278-c618-11e2-9429-23021cc7c3dc.jpg)
