### PR TITLE
Fix line number CSS Bug

### DIFF
--- a/wp-syntax.php
+++ b/wp-syntax.php
@@ -226,7 +226,10 @@ if ( ! class_exists( 'WP_Syntax' ) ) {
 		public static function lineNumbers( $code, $start ) {
 
 			$line_count = count( explode( "\n", $code ) );
-			$output = '<pre>';
+			$num_digits = strlen(strval($start + $line_count));
+			$px_width_needed = 8 * $num_digits;
+
+			$output = "<pre style=\"width: {$px_width_needed}px !important;\">";
 
 			for ( $i = 0; $i < $line_count; $i++ ) {
 				$output .= ( $start + $i ) . "\n";


### PR DESCRIPTION
The changes in this pull request aim to fix issue #4 and to fix issue #10.

In this pull request, I chose to set the width on the pre tag inline.  Given my setup, I found that the width (in pixels) of the pre element needs to be 8 times the number of digits in the largest number we are trying to display.

I will now show a series of screenshots that capture the changes this pull request will result in.
## Screenshots
### Current Issue

![testing_syntax_highlighting___grumpyrainbow com-3](https://f.cloud.github.com/assets/1584123/1609900/0ba1bd0a-5560-11e3-948c-12c0239c21c8.png)
### With Changes [line="1"]

![testing_syntax_highlighting___grumpyrainbow com-2](https://f.cloud.github.com/assets/1584123/1609908/5278b508-5560-11e3-8254-c62939231eb8.png)
### With Changes [line="1000"]

![testing_syntax_highlighting___grumpyrainbow com-4](https://f.cloud.github.com/assets/1584123/1609915/90b7b5d0-5560-11e3-808c-20a754b1b974.png)
## Comments

This is just one way of handling this problem.  If you have other ideas, I'm open to hearing them.

Take care!
